### PR TITLE
Add TMS Reco package (dune-tms)

### DIFF
--- a/packages/dune-tms/package.py
+++ b/packages/dune-tms/package.py
@@ -1,3 +1,8 @@
+# This package.py written by Liam O'Sullivan <liam.osullivan@uni-mainz.de>
+# For reasons™, explicitly including root and geant4 as dependencies
+# causes the build to fail (missing blas or whatevs).
+# If you spack load root and geant4 it builds fine though.
+
 from spack.package import *
 
 class DuneTms(CMakePackage):

--- a/packages/dune-tms/package.py
+++ b/packages/dune-tms/package.py
@@ -1,0 +1,38 @@
+from spack.package import *
+
+class DuneTms(CMakePackage):
+    """dune-tms -- TMS reconstruction and simulation """
+
+    license("MIT")
+    homepage = "https://github.com/DUNE/dune-tms"
+    git = "https://github.com/DUNE/dune-tms.git"
+
+    executables = ["^BField_tester$",
+                   "^BetheBloch_Example$",
+                   "^CherryPickEvents$",
+                   "^ConvertToTMSTree$",
+                   "^DBSCAN_test$",
+                   "^DrawEvents$",
+                   "^ShootRay$",
+                   "^TrackLengthTester$"]
+
+    maintainers("LiamOS") # Maintainer on FNAL spack 'n github
+
+    version("main", branch="main")
+    version("develop", branch="main")
+
+    depends_on("cmake", type="build")
+    depends_on("nlohmann-json")
+    depends_on("edep-sim")
+    #depends_on("root")
+    #depends_on("geant4")
+
+    def setup_run_environment(self, env): 
+        env.set("TMS_DIR", self.prefix)
+
+class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):
+    def cmake_args(self):
+        args = [
+            self.define("CMAKE_VERBOSE_MAKEFILE", True)
+        ]  
+        return args

--- a/packages/edep-sim/package.py
+++ b/packages/edep-sim/package.py
@@ -1,7 +1,7 @@
-# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
-# Spack Project Developers. See the top-level COPYRIGHT file for details.
-#
-# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+# This package.py written by Liam O'Sullivan <liam.osullivan@uni-mainz.de>
+# For reasons™, explicitly including root and geant4 as dependencies
+# causes the build to fail (missing blas or whatevs).
+# If you spack load root and geant4 it builds fine though.
 
 from spack.package import *
 

--- a/packages/edep-sim/package.py
+++ b/packages/edep-sim/package.py
@@ -39,6 +39,7 @@ class EdepSim(CMakePackage):
     def setup_run_environment(self, env): 
         env.set("EDEP_ROOT", self.prefix)
         env.set("EDEPSIM_LIB", self.prefix.lib)
+        env.set("EDEPSIM_INC", self.prefix.include)
 
 
 class CMakeBuilder(spack.build_systems.cmake.CMakeBuilder):


### PR DESCRIPTION
Includes a package.py for dune-tms, with edep-sim as a dependency.
Edit to edep-sim package.py comments.