### PR TITLE
Mengel spack 1.0.0 build changes

### DIFF
--- a/spack_repo/dune_spack/packages/duneana/package.py
+++ b/spack_repo/dune_spack/packages/duneana/package.py
@@ -14,6 +14,7 @@ class Duneana(CMakePackage, FnalGithubPackage):
     repo = "DUNE/duneana"
     version_patterns = ["09_00_00d00", "09.14.19"]
 
+    version("10_09_00d00", sha256="db3e5b55984992bd516f4ee4722c72400116d9e4cd5b3704b416459e65e5af72")
     version("10_08_02d00", sha256="7f9faf6bff0926c9958eaa2f74db6410559598788f48c5f0117e313d12fccee4")
     version("10_00_03d00", sha256="0db33f7a710b5a85c669d77db6a735fdbb354c70feb689051b080797d8d26712")
     version("09_92_00d00", sha256="fc0700c36f3334f70f7b3929b868bdf530a9f71f44dc205daa052d3755e4d08f")
@@ -32,6 +33,20 @@ class Duneana(CMakePackage, FnalGithubPackage):
     patch('v09_81_00d00.patch', when='@09_81_00d00')
     patch('v09_92_00d00.patch', when='@09_92_00d00')
 
+    def patch(self):
+
+        filter_file(
+                r'find_package\( duneanaobj REQUIRED EXPORT \)',
+                '',
+                'CMakeLists.txt',
+            )
+        for f in ('WireAna','AnaTree','CAFMaker'):
+            filter_file(
+                     r'duneanaobj::[a-zA-Z0-9]*',
+                     '',
+                     f'duneana/{f}/CMakeLists.txt',
+                 )
+
     depends_on("c", type="build")
     depends_on("cxx", type="build")
     depends_on("duneanaobj")
@@ -43,12 +58,14 @@ class Duneana(CMakePackage, FnalGithubPackage):
     depends_on("systematicstools")
     depends_on("cetmodules", type="build")
     depends_on("cmake", type="build")
+    depends_on("duneopdet")
 
     def cmake_args(self):
         args = [
             self.define_from_variant("CMAKE_CXX_STANDARD", "cxxstd"),
             self.define("CMAKE_MODULE_PATH", "%s/Modules;%s/Modules" %
-                       (self.spec['nufinder'].prefix, self.spec['larfinder'].prefix))
+                       (self.spec['nufinder'].prefix, self.spec['larfinder'].prefix)),
+            self.define("CMAKE_CXX_FLAGS","-I%s" % self.spec['duneanaobj'].prefix.include),
         ] 
         return args
 

--- a/spack_repo/dune_spack/packages/duneanaobj/package.py
+++ b/spack_repo/dune_spack/packages/duneanaobj/package.py
@@ -12,6 +12,7 @@ class Duneanaobj(CMakePackage, FnalGithubPackage):
     """Duneanaobj"""
 
     repo = "DUNE/duneanaobj"
+    git  = "https://github.com/DUNE/duneanaobj"
     version_patterns = ["09_00_00", "09.14.19"]
 
     version("03_10_00", sha256="35f025b77b3f5c6cc4666d1bbd04b2ff8f837a51670bbe5c0d80a7e3145164d8")
@@ -49,6 +50,8 @@ class Duneanaobj(CMakePackage, FnalGithubPackage):
     def cmake_args(self):
         args = [
             self.define_from_variant("CMAKE_CXX_STANDARD", "cxxstd"),
+            self.define("CMAKE_BUILD_DIR", self.prefix),
+            self.define("CMAKE_INSTALL_INCLUDEDIR", self.prefix.include),
         ] 
         return args
 
@@ -56,7 +59,7 @@ class Duneanaobj(CMakePackage, FnalGithubPackage):
         spack_env.set("LD_LIBRARY_PATH", "%s/root" % self.spec["root"].prefix.lib)
         spack_env.set("ROOT_INC", "%s" % self.spec["root"].prefix.include)
         spack_env.set("DUNEANAOBJ_DIR", "%s" % os.path.realpath(self.stage.source_path))
-        spack_env.set("SRPROXY_INC", "%s" % os.path.realpath(self.stage.build_directory))
+        spack_env.set("SRPROXY_INC", "%s" % os.path.realpath(self.build_directory))
 
     def setup_run_environment(self, run_env):
         run_env.prepend_path("CET_PLUGIN_PATH", self.prefix.lib)

--- a/spack_repo/dune_spack/packages/dunecore/package.py
+++ b/spack_repo/dune_spack/packages/dunecore/package.py
@@ -12,8 +12,10 @@ class Dunecore(CMakePackage, FnalGithubPackage):
     """Dunecore"""
 
     repo = "DUNE/dunecore"
+    git = "https://github.com/DUNE/dunecore"
     version_patterns = ["09_00_00d00", "09.14.19"]
 
+    version("10_09_00d00", sha256="3c5d359cfd658304a8de2531cafc1939a413cd0030de68c98f4c453c56239eb4") 
     version("10_08_02d00", sha256="e2f0667237b7982461fb6770805ee265dce76ba53e97ada93c33046dfb4a557c")
     version("10_00_03d00", sha256="853476dfd8e1c97e34e03d0bf47a393a4de2e61af3b7623a41a7004c24851647")
     version("09_92_00d00", sha256="37edf3afd3be02cbd64adef1ab1c5c9c7e275d7ffcee44ffce2172451f94dbcd")
@@ -37,32 +39,56 @@ class Dunecore(CMakePackage, FnalGithubPackage):
         filter_file(r'find_package\( nusimdata REQUIRED EXPORT \)$',
                     'find_package( nusimdata REQUIRED EXPORT )\nfind_package( gallery REQUIRED EXPORT )',
                     'CMakeLists.txt')
+        filter_file(
+                "artdaq_core",
+                "artdaq-core",
+                "CMakeLists.txt"
+                )
+        filter_file(
+                "artdaq_core",
+                "artdaq-core",
+                "dunecore/RawDecoding/CMakeLists.txt"
+                )
+        filter_file(
+                "artdaq-core::artdaq-core_Data",
+                "artdaq-core::Data",
+                "dunecore/RawDecoding/CMakeLists.txt"
+                )
+        filter_file(
+                "artdaq-core::artdaq-core_Utilities",
+                "artdaq-core::Utilities",
+                "dunecore/RawDecoding/CMakeLists.txt"
+                )
 
     depends_on("c", type="build")
     depends_on("cxx", type="build")
-    depends_on("boost")
-    depends_on("geant4")
-    depends_on("root")
-    depends_on("eigen")
+    depends_on("cetmodules", type="build")
+    depends_on("cmake", type="build")
     depends_on("art")
-    depends_on("art-root-io")
     depends_on("artdaq-core")
-    depends_on("trace")
+    depends_on("art-root-io")
+    depends_on("boost")
     depends_on("canvas")
     depends_on("canvas-root-io")
-    depends_on("cetlib-except")
     depends_on("cetlib")
+    depends_on("cetlib-except")
     depends_on("clhep")
     depends_on("critic")
+    depends_on("dunedaqdataformats")
+    depends_on("dunedetdataformats")
+    depends_on("dunepdlegacy")
+    depends_on("duneutil")
+    depends_on("eigen")
+    depends_on("fftw")
     depends_on("fhicl-cpp")
-    depends_on("nufinder")
+    depends_on("gallery")
+    depends_on("geant4")
     depends_on("genie")
+    depends_on("hdf5@1.12.2")
     depends_on("hep-concurrency")
+    depends_on("highfive")
     depends_on("ifdh-art")
     depends_on("ifdhc")
-    depends_on("dunepdlegacy")
-    depends_on("gallery")
-    depends_on("duneutil")
     depends_on("larana")
     depends_on("larcore")
     depends_on("larcorealg")
@@ -75,33 +101,30 @@ class Dunecore(CMakePackage, FnalGithubPackage):
     depends_on("larreco")
     depends_on("larsim")
     depends_on("messagefacility")
+    depends_on("nlohmann-json")
     depends_on("nuevdb")
+    depends_on("nufinder")
     depends_on("nug4")
     depends_on("nugen")
     depends_on("nurandom")
     depends_on("nusimdata")
     depends_on("nutools")
     depends_on("pandora")
-    depends_on("dunedaqdataformats")
-    depends_on("dunedetdataformats")
     depends_on("postgresql")
-    depends_on("fftw")
+    depends_on("root")
     depends_on("sqlite")
-    depends_on("nlohmann-json")
-    depends_on("highfive")
-    depends_on("hdf5@1.12.2")
-    depends_on("cetmodules", type="build")
-    depends_on("cmake", type="build")
+    depends_on("trace")
 
     def cmake_args(self):
         args = [
             self.define_from_variant("CMAKE_CXX_STANDARD", "cxxstd"),
-            self.define("CMAKE_MODULE_PATH", "%s/Modules" % self.spec['nufinder'].prefix)
+            self.define("CMAKE_MODULE_PATH", "%s/Modules" % self.spec['nufinder'].prefix),
         ] 
         return args
 
     def setup_build_environment(self, spack_env):
         spack_env.set("LD_LIBRARY_PATH", "%s/root" % self.spec["root"].prefix.lib)
+        spack_env.prepend_path("CMAKE_PREFIX_PATH", self.build_directory)
 
     def setup_run_environment(self, run_env):
         run_env.prepend_path("CET_PLUGIN_PATH", self.prefix.lib)

--- a/spack_repo/dune_spack/packages/dunedataprep/package.py
+++ b/spack_repo/dune_spack/packages/dunedataprep/package.py
@@ -14,6 +14,7 @@ class Dunedataprep(CMakePackage, FnalGithubPackage):
     repo = "DUNE/dunedataprep"
     version_patterns = ["09_00_00d00", "09.14.19"]
 
+    version("10_09_00d00", sha256="24f24adb8991c9ea4c51d30c4c557c29e9880b7ec759742bc5e4691a206a8fb3")
     version("10_08_02d00", sha256="51a4e1511d88139e96e024150a1da592104d92d16e885dbe150fc9a7ef39406f")
     version("10_00_03d00", sha256="673f451a37a0fb0884aa5f739af3bd66b15ef614e8e5c532d81c91c8c0ad65c5")
     version("09_92_00d00", sha256="6f636aa889a8b2e3b926c003e96bec098d79bc025417a2ae281750eb9ce0d57c")
@@ -31,11 +32,25 @@ class Dunedataprep(CMakePackage, FnalGithubPackage):
 
     patch('v09_81_00d00.patch', when='@09_81_00d00')
 
+    def patch(self):
+
+        filter_file(
+                'find_package\( jsoncpp REQUIRED \)',
+                'pkg_check_modules( JSONCPP REQUIRED IMPORTED_TARGET jsoncpp )',
+                'CMakeLists.txt',
+            )
+        filter_file(
+                'jsoncpp',
+                'PkgConfig::jsoncpp',
+                'dunedataprep/DataPrep/WctTool/CMakeLists.txt',
+            )
+
     depends_on("c", type="build")
     depends_on("cxx", type="build")
     depends_on("dunecore")
     depends_on("jsonnet")
     depends_on("jsoncpp")
+    depends_on("larwirecell")
     depends_on("wire-cell-toolkit")
     depends_on("cetmodules", type="build")
     depends_on("cmake", type="build")

--- a/spack_repo/dune_spack/packages/dunedetdataformats/package.py
+++ b/spack_repo/dune_spack/packages/dunedetdataformats/package.py
@@ -10,6 +10,7 @@ from spack.package import *
 class Dunedetdataformats(Package):
     """Dunedetdataformats"""
     url = "https://github.com/DUNE/dunedetdataformats/archive/refs/tags/v4_4_5.tar.gz"
+    version("4_4_5", sha256="82e69cb0397d910f53664a8276766230489440f37001a4980520b13c7e23b4fc")
     version("4_4_4", url = "https://github.com/DUNE/dunedetdataformats/archive/refs/tags/v4_4_4.tar.gz", sha256="ae4f18a4f3c09f503a0dca5373fb9b08ad04bfc4ead323605121ff3ec76a22df")
     version("4_4_0", url = "https://github.com/DUNE/dunedetdataformats/archive/refs/tags/v4_4_0.tar.gz", sha256="1312f255869f6b021df8c9a7885925192e62094f46808d3b7f6bd99d6efc0a20")
     version("4_1_0", url = "https://github.com/DUNE/dunedetdataformats/archive/refs/tags/v4_1_0.tar.gz", sha256="479de5f1392b6303c258bced663b9aebd22ccd4a0aab2dd2910a9e1e295808b8")

--- a/spack_repo/dune_spack/packages/duneopdet/package.py
+++ b/spack_repo/dune_spack/packages/duneopdet/package.py
@@ -35,11 +35,16 @@ class Duneopdet(CMakePackage, FnalGithubPackage):
 
     def patch(self):
         filter_file("LANGUAGES CXX", "LANGUAGES CXX C", "CMakeLists.txt")
+        filter_file(
+                r'find_package\( dunecore REQUIRED EXPORT \)',
+                'find_package( dunecore REQUIRED EXPORT )\nfind_package( duneprototypes REQUIRED EXPORT)',
+                'CMakeLists.txt'
+            )
 
-    depends_on("duneana")
     depends_on("c", type="build")
     depends_on("cxx", type="build")
     depends_on("dunecore")
+    # depends_on("duneprototypes")
     depends_on("nlohmann-json")
     depends_on("cetmodules", type="build")
     depends_on("cmake", type="build")

--- a/spack_repo/dune_spack/packages/duneopdet/package.py
+++ b/spack_repo/dune_spack/packages/duneopdet/package.py
@@ -44,7 +44,7 @@ class Duneopdet(CMakePackage, FnalGithubPackage):
     depends_on("c", type="build")
     depends_on("cxx", type="build")
     depends_on("dunecore")
-    # depends_on("duneprototypes")
+    depends_on("duneprototypes")
     depends_on("nlohmann-json")
     depends_on("cetmodules", type="build")
     depends_on("cmake", type="build")

--- a/spack_repo/dune_spack/packages/dunepdlegacy/package.py
+++ b/spack_repo/dune_spack/packages/dunepdlegacy/package.py
@@ -30,6 +30,28 @@ class Dunepdlegacy(CMakePackage, FnalGithubPackage):
     patch('v1_01_05.patch', when='@1_01_05')
     patch('v09_81_00d00.patch', when='@1_01_00')
 
+    def patch(self):
+        filter_file(
+                "artdaq_core",
+                "artdaq-core",
+                "CMakeLists.txt"
+                )
+        filter_file(
+                "artdaq_core",
+                "artdaq-core",
+                "dunepdlegacy/Overlays/CMakeLists.txt"
+                )
+        filter_file(
+                "artdaq-core::artdaq-core_Data",
+                "artdaq-core::Data",
+                "dunepdlegacy/Overlays/CMakeLists.txt"
+                )
+        filter_file(
+                "artdaq-core::artdaq-core_Utilities",
+                "artdaq-core::Utilities",
+                "dunepdlegacy/Overlays/CMakeLists.txt"
+                )
+
     depends_on("c", type="build")
     depends_on("cxx", type="build")
     depends_on("gallery")

--- a/spack_repo/dune_spack/packages/duneprototypes/package.py
+++ b/spack_repo/dune_spack/packages/duneprototypes/package.py
@@ -31,14 +31,43 @@ class Duneprototypes(CMakePackage, FnalGithubPackage):
 
     patch('v09_81_00d00.patch', when='@09_81_00d00')
 
+    def patch(self):
+        # clean out vestigial dunesim, duneprototypes references
+        filter_file(
+            '#include "dunesim/DetSim/Service/DPhaseSimChannelExtractService.h"',
+            '',
+            'duneprototypes/Protodune/dualphase/Purity_module.cc'
+            )
+        filter_file(
+                'r#include "duneopdet.*',
+                '',
+                'duneprototypes/Protodune/singlephase/NearlineMonitor/PlotOpticalDetails_module.cc',
+            )
+        filter_file(
+            'dunesim::DetSim',
+            '',
+            'duneprototypes/Protodune/dualphase/CMakeLists.txt'
+            )
+        filter_file(
+            'find_package( dunesim REQUIRED EXPORT )',
+            '',
+            'CMakeLists.txt'
+            )
+        filter_file(
+            'find_package( duneopdet REQUIRED EXPORT )',
+            '',
+            'CMakeLists.txt'
+            )
+
     depends_on("c", type="build")
     depends_on("cxx", type="build")
-    depends_on("dunesim")
+    depends_on("cetmodules", type="build")
+    depends_on("cmake", type="build")
+    # makes a cycle, may not actually be used(!)
+    #depends_on("dunesim")
     depends_on("dunecalib")
     depends_on("duneopdet")
     depends_on("nuevdb")
-    depends_on("cetmodules", type="build")
-    depends_on("cmake", type="build")
 
 
     def cmake_args(self):

--- a/spack_repo/dune_spack/packages/duneprototypes/package.py
+++ b/spack_repo/dune_spack/packages/duneprototypes/package.py
@@ -49,24 +49,56 @@ class Duneprototypes(CMakePackage, FnalGithubPackage):
             'duneprototypes/Protodune/dualphase/CMakeLists.txt'
             )
         filter_file(
-            'find_package( dunesim REQUIRED EXPORT )',
+            'find_package\\( (dunesim|duneopdet) REQUIRED EXPORT \\)',
             '',
             'CMakeLists.txt'
             )
         filter_file(
-            'find_package( duneopdet REQUIRED EXPORT )',
-            '',
-            'CMakeLists.txt'
+                'duneopdet::OpticalDetector',
+                '',
+                'duneprototypes/Protodune/singlephase/NearlineMonitor/CMakeLists.txt',
             )
+        filter_file(
+                '#include "duneopdet.*',
+                '',
+                'duneprototypes/Protodune/singlephase/NearlineMonitor/PlotOpticalDetails_module.cc',
+            )
+
+        for cmf in (
+                'CMakeLists.txt',
+                'duneprototypes/Coldbox/hd/CMakeLists.txt',
+                'duneprototypes/Coldbox/vd/CMakeLists.txt',
+                'duneprototypes/Iceberg/RawDecoding/CMakeLists.txt',
+                'duneprototypes/Protodune/dualphase/CMakeLists.txt',
+                'duneprototypes/Protodune/dualphase/Purity_module.cc',
+                'duneprototypes/Protodune/hd/RawDecoding/CMakeLists.txt',
+                'duneprototypes/Protodune/singlephase/NearlineMonitor/CMakeLists.txt',
+                'duneprototypes/Protodune/singlephase/NearlineMonitor/PlotOpticalDetails_module.cc',
+                'duneprototypes/Protodune/singlephase/PhotonDetectors/CMakeLists.txt',
+                'duneprototypes/Protodune/singlephase/RawDecoding/CMakeLists.txt',
+                'duneprototypes/Protodune/spsbsm/SPSFilter/CMakeLists.txt',
+                'duneprototypes/Protodune/spsbsm/SPSProducer/CMakeLists.txt',
+                'duneprototypes/Protodune/vd/RawDecoding/CMakeLists.txt'):
+            filter_file(
+                'artdaq_core',
+                'artdaq-core',
+                cmf
+                )
+            filter_file(
+                'artdaq.core::artdaq.core_(Utilities|Data)',
+                'artdaq-core::\\1',
+                cmf
+                )
+
 
     depends_on("c", type="build")
     depends_on("cxx", type="build")
     depends_on("cetmodules", type="build")
     depends_on("cmake", type="build")
+    depends_on("dunecalib")
     # makes a cycle, may not actually be used(!)
     #depends_on("dunesim")
-    depends_on("dunecalib")
-    depends_on("duneopdet")
+    #depends_on("duneopdet")
     depends_on("nuevdb")
 
 


### PR DESCRIPTION
Not sure you actually want to merge this, but these are the hacks I made to get (most) of the dune components building on spack-1.0.0. There are a few packages that seem to be mutually dependent 
that need  code changes, but this gets lots of it going.  Feel free to cherry-pick anything useful,
or just drop it; but I thought at least parts of it might be useful.   For example, I'm working around the fact that duneadnaobj doesn't install any CMake files, but since it seems to be all headers, I just put it in the include path and removed the CMake library references, this may be better fixed by putting the CMake bits in the install for duneanaobj....
similarly, jsoncpp doesn't have CMake bits, but does have pkgconfig bits for finding it...