### PR TITLE
dune-op-det needs  protobuf + grpc in CMAKE_PREFIX_PATH 

### DIFF
--- a/spack_repo/dune_spack/packages/dune_op_det/package.py
+++ b/spack_repo/dune_spack/packages/dune_op_det/package.py
@@ -61,6 +61,9 @@ class DuneOpDet(CMakePackage):
     depends_on("nlohmann-json")
     depends_on("larfinder")
     depends_on("py-tensorflow")
+    depends_on("protobuf")
+    depends_on("grpc")
+    depends_on("larsimdnn")
     depends_on("cetmodules", type="build")
     depends_on("cmake", type="build")
 


### PR DESCRIPTION
for find_package(TensorFlow) to work in global build and needs larsimdnn in CMAKE_PREFIX_PATH to set larsimdnn target