### PR TITLE
fixes for dunesw 10.20.03d01

### DIFF
--- a/spack_repo/dune_spack/packages/dunereco/package.py
+++ b/spack_repo/dune_spack/packages/dunereco/package.py
@@ -42,6 +42,7 @@ class Dunereco(CMakePackage):
         description="Use the specified C++ standard when building.",
     )
 
+    patch("v10_20_03d01.patch", when="@10.20.03d01")
     patch('v09_81_00d00.patch', when='@09.81.00d00')
 
     depends_on("c", type="build")

--- a/spack_repo/dune_spack/packages/dunereco/v10_20_03d01.patch
+++ b/spack_repo/dune_spack/packages/dunereco/v10_20_03d01.patch
@@ -1,0 +1,36 @@
+diff --git a/dunereco/CMakeLists.txt b/dunereco/CMakeLists.txt
+index 745c2faa..4c67092e 100644
+--- a/dunereco/CMakeLists.txt
++++ b/dunereco/CMakeLists.txt
+@@ -18,31 +18,6 @@ add_subdirectory(VLNets)
+ add_subdirectory(PointResTree)
+ add_subdirectory(WireFilter)
+ 
+-# Supera
+-#
+-# Why are we checking explicitly for git submodule initialization?
+-# ----------------------------------------------------------------
+-# Because it is stored as a git submodule, it should be initialized first before
+-# any build is attempted. `mrb gitCheckout` should run `--recurse-submodules` to
+-# this effect. However, it is implemented in a hacky way: the option for submodules
+-# is only added to `mrb gitCheckout` command if we are cloning from SBNSoftware/sbncode
+-# and nothing else. This means cloning from SBNSoftware/sbncode#somePRnumber will
+-# NOT carry this option. This type of cloning can happen in CI builds for example.
+-# In other words, we need to fix the hack with another hack: if Supera does not
+-# look initialized, we take the matter in our hands and run the git submodule
+-# initialization command.
+-#
+-# (This explanation above might be relevant for any other git submodules.)
+-if ( NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/Supera/.git" )
+-  execute_process(COMMAND git submodule update --init --recursive
+-                  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+-endif()
+-
+-# We need to run Supera/setup.sh first, otherwise it won't have a CMakeLists.txt.
+-execute_process(COMMAND sh ${CMAKE_CURRENT_SOURCE_DIR}/Supera/setup.sh dune
+-                WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/Supera )
+-                
+-add_subdirectory(Supera)
+ # these two were not built in dunetpc at the time of the split
+ # add_subdirectory(SNSlicer)
+ # add_subdirectory(SNUtils)

--- a/spack_repo/dune_spack/packages/protoduneana/package.py
+++ b/spack_repo/dune_spack/packages/protoduneana/package.py
@@ -60,6 +60,7 @@ class Protoduneana(CMakePackage):
     depends_on("hep-hpc")
     depends_on("duneopdet")
     depends_on("duneprototypes")
+    depends_on("dunereco", when="@10.12:")
     depends_on("dunesim")
     depends_on("python")
     depends_on("py-tensorflow")


### PR DESCRIPTION
add a patch file to disable the Supera submodule in dunereco, which does not seem to play nicely with spack. we'll need a longer term fix for that. protoduneana also has a new dunereco dependency, which was introduced in 10.12.