### PR TITLE
dunesw: add dune-pardata and larg4 test dependencies

### DIFF
--- a/spack_repo/dune_spack/packages/dunesw/package.py
+++ b/spack_repo/dune_spack/packages/dunesw/package.py
@@ -63,8 +63,8 @@ class Dunesw(CMakePackage):
     depends_on("cetmodules", type="build")
     depends_on("cmake", type="build")
     depends_on("justin", type="run")
-    depends_on("larg4", type="run")
-    depends_on("dune-pardata", type="run")
+    depends_on("larg4", type=("test","run"))
+    depends_on("dune-pardata", type=("test","run"))
 
     def cmake_args(self):
         args = [


### PR DESCRIPTION
- **dunesw: make larg4 and dune-pardata run and test dependencies**

I set up dune-pardata as an external in the unified environment with
```
    dune-pardata:
      externals:
      - spec: dune-pardata@01.84.00
        prefix: /cvmfs/dune.opensciencegrid.org/products/dune/dune_pardata/v01_84_00
```