### PR TITLE
remove stashcache dunepardata path

### DIFF
--- a/spack_repo/dune_spack/packages/dunesw/package.py
+++ b/spack_repo/dune_spack/packages/dunesw/package.py
@@ -7,9 +7,6 @@ from spack_repo.builtin.build_systems.cmake import CMakePackage
 from spack.package import *
 
 
-DUNE_PARDATA_DIR = "/cvmfs/dune.osgstorage.org/pnfs/fnal.gov/usr/dune/persistent/stash"
-
-
 class Dunesw(CMakePackage):
     """Dunesw"""
 
@@ -80,7 +77,6 @@ class Dunesw(CMakePackage):
         run_env.prepend_path("ROOT_INCLUDE_PATH", self.prefix.include)
         run_env.append_path("FHICL_FILE_PATH", "{0}/fcl".format(self.prefix))
         run_env.append_path("FW_SEARCH_PATH", "{0}/gdml".format(self.prefix))
-        run_env.prepend_path("FW_SEARCH_PATH", DUNE_PARDATA_DIR)
 
     def setup_dependent_run_environment(self, run_env, dspec):
         run_env.prepend_path("CET_PLUGIN_PATH", self.prefix.lib)
@@ -88,4 +84,3 @@ class Dunesw(CMakePackage):
         run_env.prepend_path("ROOT_INCLUDE_PATH", self.prefix.include)
         run_env.append_path("FHICL_FILE_PATH", "{0}/fcl".format(self.prefix))
         run_env.append_path("FW_SEARCH_PATH", "{0}/gdml".format(self.prefix))
-        run_env.prepend_path("FW_SEARCH_PATH", DUNE_PARDATA_DIR)


### PR DESCRIPTION
with the addition of a `dune-pardata` package, the `dunesw` package no longer needs to append the stashcache dunepardata path to `FW_SEARCH_PATH`. this PR removes that environment variable from the `dunesw` recipe, so it doesn't collide with the directory set up by the package.