### PR TITLE
Add missing dependencies for unit tests

### DIFF
--- a/spack_repo/dune_spack/packages/dunepdlegacy/package.py
+++ b/spack_repo/dune_spack/packages/dunepdlegacy/package.py
@@ -57,3 +57,5 @@ class Dunepdlegacy(CMakePackage):
         ] 
         return args
 
+    def setup_run_environment(self, env):
+        env.prepend_path("FW_SEARCH_PATH", self.prefix.files)

--- a/spack_repo/dune_spack/packages/duneprototypes/package.py
+++ b/spack_repo/dune_spack/packages/duneprototypes/package.py
@@ -62,6 +62,7 @@ class Duneprototypes(CMakePackage):
     depends_on("cetmodules", type="build")
     depends_on("cmake", type="build")
     depends_on("dunecalib")
+    depends_on("dunepdlegacy")
     # makes a cycle, may not actually be used(!)
     #depends_on("dunesim")
     #depends_on("duneopdet")


### PR DESCRIPTION
The `dunepdlegacy` package is currently an implicit dependency of `duneprototypes`.  This PR makes the dependency explicit so that MPD can locate the `protoDUNETPCChannelMap_RCE_v4.txt` file used by two of the `duneprototypes` unit tests.