### PR TITLE
remove dune pardata

### DIFF
--- a/spack_repo/dune_spack/packages/dunesw/package.py
+++ b/spack_repo/dune_spack/packages/dunesw/package.py
@@ -65,7 +65,6 @@ class Dunesw(CMakePackage):
     depends_on("cmake", type="build")
     depends_on("justin", type="run")
     depends_on("larg4", type=("test","run"))
-    depends_on("dune-pardata", type=("test","run"))
 
     def cmake_args(self):
         args = [

--- a/spack_repo/dune_spack/packages/dunesw/package.py
+++ b/spack_repo/dune_spack/packages/dunesw/package.py
@@ -7,6 +7,9 @@ from spack_repo.builtin.build_systems.cmake import CMakePackage
 from spack.package import *
 
 
+DUNE_PARDATA_DIR = "/cvmfs/dune.osgstorage.org/pnfs/fnal.gov/usr/dune/persistent/stash"
+
+
 class Dunesw(CMakePackage):
     """Dunesw"""
 
@@ -78,6 +81,7 @@ class Dunesw(CMakePackage):
         run_env.prepend_path("ROOT_INCLUDE_PATH", self.prefix.include)
         run_env.append_path("FHICL_FILE_PATH", "{0}/fcl".format(self.prefix))
         run_env.append_path("FW_SEARCH_PATH", "{0}/gdml".format(self.prefix))
+        run_env.prepend_path("FW_SEARCH_PATH", DUNE_PARDATA_DIR)
 
     def setup_dependent_run_environment(self, run_env, dspec):
         run_env.prepend_path("CET_PLUGIN_PATH", self.prefix.lib)
@@ -85,3 +89,4 @@ class Dunesw(CMakePackage):
         run_env.prepend_path("ROOT_INCLUDE_PATH", self.prefix.include)
         run_env.append_path("FHICL_FILE_PATH", "{0}/fcl".format(self.prefix))
         run_env.append_path("FW_SEARCH_PATH", "{0}/gdml".format(self.prefix))
+        run_env.prepend_path("FW_SEARCH_PATH", DUNE_PARDATA_DIR)


### PR DESCRIPTION
remove dependency on dune-pardata spack package, as we are retiring the distribution of data files through a package dependency. files have been consolidated in a path on stashcache, which has been prepended to FW_SEARCH_PATH in the dunesw package recipe.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>