### PR TITLE
set WIRECELL_PATH in dunereco

### DIFF
--- a/spack_repo/dune_spack/packages/dunereco/package.py
+++ b/spack_repo/dune_spack/packages/dunereco/package.py
@@ -152,12 +152,12 @@ class Dunereco(CMakePackage):
         run_env.prepend_path("CET_PLUGIN_PATH", self.prefix.lib)
         run_env.prepend_path("PATH", self.prefix.bin)
         run_env.prepend_path("ROOT_INCLUDE_PATH", self.prefix.include)
-        run_env.append_path("FHICL_FILE_PATH", "{0}/fcl".format(self.prefix))
-        run_env.append_path("FW_SEARCH_PATH", "{0}/gdml".format(self.prefix))
+        run_env.append_path("FHICL_FILE_PATH", self.prefix.fcl)
+        run_env.append_path("FW_SEARCH_PATH", self.prefix.gdml)
 
     def setup_dependent_run_environment(self, run_env, dspec):
         run_env.prepend_path("CET_PLUGIN_PATH", self.prefix.lib)
         run_env.prepend_path("PATH", self.prefix.bin)
         run_env.prepend_path("ROOT_INCLUDE_PATH", self.prefix.include)
-        run_env.append_path("FHICL_FILE_PATH", "{0}/fcl".format(self.prefix))
-        run_env.append_path("FW_SEARCH_PATH", "{0}/gdml".format(self.prefix))
+        run_env.append_path("FHICL_FILE_PATH", self.prefix.fcl)
+        run_env.append_path("FW_SEARCH_PATH", self.prefix.gdml)

--- a/spack_repo/dune_spack/packages/dunereco/package.py
+++ b/spack_repo/dune_spack/packages/dunereco/package.py
@@ -154,6 +154,7 @@ class Dunereco(CMakePackage):
         run_env.prepend_path("ROOT_INCLUDE_PATH", self.prefix.include)
         run_env.append_path("FHICL_FILE_PATH", self.prefix.fcl)
         run_env.append_path("FW_SEARCH_PATH", self.prefix.gdml)
+        run_env.prepend_path("WIRECELL_PATH", self.prefix.join("wire-cell-cfg"))
 
     def setup_dependent_run_environment(self, run_env, dspec):
         run_env.prepend_path("CET_PLUGIN_PATH", self.prefix.lib)
@@ -161,3 +162,4 @@ class Dunereco(CMakePackage):
         run_env.prepend_path("ROOT_INCLUDE_PATH", self.prefix.include)
         run_env.append_path("FHICL_FILE_PATH", self.prefix.fcl)
         run_env.append_path("FW_SEARCH_PATH", self.prefix.gdml)
+        run_env.prepend_path("WIRECELL_PATH", self.prefix.join("wire-cell-cfg"))


### PR DESCRIPTION
the `dunereco` package contains a `wire-cell-cfg` directory that needs to be prepended to `WIRECELL_PATH`. this PR makes this change, and also cleans up the syntax for other environment variables set in that recipe.